### PR TITLE
add space to python -m json.tool for readability

### DIFF
--- a/servers/admin/README.md
+++ b/servers/admin/README.md
@@ -24,4 +24,4 @@ bin/setup.sh
 ````
 
 ## Troubleshooting
-`setup.sh` fails if the json file is malformed. You can use python's json package for error checking: `python -mjson.tool ../../conf/init.json`.
+`setup.sh` fails if the json file is malformed. You can use python's json package for error checking: `python -m json.tool ../../conf/init.json`.


### PR DESCRIPTION
Although python -mjson.tool works, I believe it is standard to have a space between the -m flag and the module.
