### PR TITLE
Correct @tparam usages.

### DIFF
--- a/core/src/main/scala/controller/java/JavaAlgorithm.scala
+++ b/core/src/main/scala/controller/java/JavaAlgorithm.scala
@@ -34,11 +34,11 @@ import scala.reflect._
  * A local algorithm runs locally within a single machine and produces a model
  * that can fit within a single machine.
  *
- * @param <AP> Algorithm Parameters
- * @param <PD> Prepared Data
- * @param <M> Model
- * @param <Q> Input Query
- * @param <P> Output Prediction
+ * @tparam AP     Algorithm Parameters
+ * @tparam PD     Prepared Data
+ * @tparam M      Model
+ * @tparam Q      Input Query
+ * @tparam P      Output Prediction
  */
 abstract class LJavaAlgorithm[AP <: Params, PD, M, Q, P]
   extends LAlgorithm[AP, PD, M, Q, P]()(
@@ -63,11 +63,11 @@ abstract class LJavaAlgorithm[AP <: Params, PD, M, Q, P]
   * A parallel algorithm can be run in parallel on a cluster and produces a
   * model that can also be distributed across a cluster.
   *
-  * @param <AP> Algorithm parameters class.
-  * @param <PD> Prepared data class.
-  * @param <M> Trained model class.
-  * @param <Q> Input query class.
-  * @param <P> Output prediction class.
+  * @tparam AP     Algorithm parameters class.
+  * @tparam PD     Prepared data class.
+  * @tparam M      Trained model class.
+  * @tparam Q      Input query class.
+  * @tparam P      Output prediction class.
   */
 abstract class PJavaAlgorithm[AP <: Params, PD, M, Q, P]
   extends BaseAlgorithm[AP, PD, M, Q, P]()(

--- a/core/src/main/scala/controller/java/JavaDataSource.scala
+++ b/core/src/main/scala/controller/java/JavaDataSource.scala
@@ -38,11 +38,11 @@ import scala.reflect._
  * A local data source runs locally within a single machine and return data that
  * can fit within a single machine.
  *
- * @param <DSP> Data Source Parameters
- * @param <DP> Data Parameters
- * @param <TD> Training Data
- * @param <Q> Input Query
- * @param <A> Actual Value
+ * @tparam DSP     Data Source Parameters
+ * @tparam DP      Data Parameters
+ * @tparam TD      Training Data
+ * @tparam Q       Input Query
+ * @tparam A       Actual Value
  */
 abstract class LJavaDataSource[DSP <: Params, DP, TD, Q, A]
   extends BaseDataSource[DSP, DP, RDD[TD], Q, A]()(
@@ -92,11 +92,11 @@ abstract class LJavaDataSource[DSP <: Params, DP, TD, Q, A]
   * A parallel data source runs locally within a single machine, or in parallel
   * on a cluster, to return data that is distributed across a cluster.
   *
-  * @param <DSP> Data source parameters class.
-  * @param <DP> Data parameters data class.
-  * @param <TD> Training data class.
-  * @param <Q> Input query class.
-  * @param <A> Actual value class.
+  * @tparam DSP     Data source parameters class.
+  * @tparam DP      Data parameters data class.
+  * @tparam TD      Training data class.
+  * @tparam Q       Input query class.
+  * @tparam A       Actual value class.
   */
 abstract class PJavaDataSource[DSP <: Params, DP, TD, Q, A]
   extends BaseDataSource[DSP, DP, TD, Q, A]()(

--- a/core/src/main/scala/controller/java/JavaEngine.scala
+++ b/core/src/main/scala/controller/java/JavaEngine.scala
@@ -30,12 +30,12 @@ import scala.collection.JavaConversions._
  * information to create workflows and deployments. In Java, use
  * JavaEngineBuilder to conveniently instantiate an instance of this class.
  *
- * @param <TD> Training Data
- * @param <DP> Data Parameters
- * @param <PD> Prepared Data
- * @param <Q> Input Query
- * @param <P> Output Prediction
- * @param <A> Actual Value
+ * @tparam TD    Training Data
+ * @tparam DP    Data Parameters
+ * @tparam PD    Prepared Data
+ * @tparam Q     Input Query
+ * @tparam P     Output Prediction
+ * @tparam A     Actual Value
  */
 class JavaEngine[TD, DP, PD, Q, P, A](
     dataSourceClass: Class[_ <: LJavaDataSource[_ <: Params, DP, TD, Q, A]],

--- a/core/src/main/scala/controller/java/JavaPreparator.scala
+++ b/core/src/main/scala/controller/java/JavaPreparator.scala
@@ -36,9 +36,9 @@ import scala.reflect._
  * A local preparator runs locally within a single machine and produces prepared
  * data that can fit within a single machine.
  *
- * @param <PP> Preparator Parameters
- * @param <TD> Training Data
- * @param <PD> Prepared Data
+ * @tparam PP     Preparator Parameters
+ * @tparam TD     Training Data
+ * @tparam PD     Prepared Data
  */
 abstract class LJavaPreparator[PP <: Params, TD, PD]
   extends BasePreparator[PP, RDD[TD], RDD[PD]]() (
@@ -60,7 +60,7 @@ abstract class LJavaPreparator[PP <: Params, TD, PD]
  * A helper concrete implementation of {@link LJavaPreparator} that pass
  * training data through without any special preparation.
  *
- * @param <TD> Training Data
+ * @tparam TD     Training Data
  */
 class LJavaIdentityPreparator[TD] extends LJavaPreparator[EmptyParams, TD, TD] {
   override def prepare(td: TD): TD = td
@@ -89,9 +89,9 @@ object LJavaIdentityPreparator {
   * A parallel preparator can be run in parallel on a cluster and produces a
   * prepared data that is distributed across a cluster.
   *
-  * @param <PP> Preparator parameters class.
-  * @param <TD> Training data class.
-  * @param <PD> Prepared data class.
+  * @tparam PP     Preparator parameters class.
+  * @tparam TD     Training data class.
+  * @tparam PD     Prepared data class.
   */
 abstract class PJavaPreparator[PP <: Params, TD, PD]
   extends BasePreparator[PP, TD, PD]() (
@@ -115,7 +115,7 @@ abstract class PJavaPreparator[PP <: Params, TD, PD]
  * A helper concrete implementation of {@link PJavaPreparator} that pass
  * training data through without any special preparation.
  *
- * @param <TD> Training Data
+ * @tparam TD     Training Data
  */
 class PJavaIdentityPreparator[TD] extends PJavaPreparator[EmptyParams, TD, TD] {
   override def prepare(jsc: JavaSparkContext, td: TD): TD = td

--- a/core/src/main/scala/controller/java/JavaServing.scala
+++ b/core/src/main/scala/controller/java/JavaServing.scala
@@ -29,9 +29,9 @@ import java.util.{ List => JList }
  * Base class of local serving. For deployment, there should only be local
  * serving class.
  *
- * @param <SP> Serving Parameters
- * @param <Q> Input Query
- * @param <P> Output Prediction
+ * @tparam SP     Serving Parameters
+ * @tparam Q      Input Query
+ * @tparam P      Output Prediction
  */
 abstract class LJavaServing[SP <: Params, Q, P]
   extends BaseServing[SP, Q, P]()(JavaUtils.fakeClassTag[SP]) {
@@ -49,8 +49,8 @@ abstract class LJavaServing[SP <: Params, Q, P]
  * A concrete implementation of {@link LJavaServing} returning the first
  * algorithm's prediction result directly without any modification.
  *
- * @param <Q> Input Query
- * @param <P> Output Prediction
+ * @tparam Q     Input Query
+ * @tparam P     Output Prediction
  */
 class LJavaFirstServing[Q, P] extends LJavaServing[EmptyParams, Q, P] {
   override def serve(query: Q, predictions: JIterable[P]): P = {

--- a/core/src/main/scala/controller/java/PJavaEngine.scala
+++ b/core/src/main/scala/controller/java/PJavaEngine.scala
@@ -17,12 +17,12 @@ import scala.collection.JavaConversions._
  * JavaEngineBuilder to conveniently instantiate an instance of this class.
  * For now it only accepts LJavaServing as the serving class.
  *
- * @param <TD> Training Data
- * @param <DP> Data Parameters
- * @param <PD> Prepared Data
- * @param <Q> Input Query
- * @param <P> Output Prediction
- * @param <A> Actual Value
+ * @tparam TD     Training Data
+ * @tparam DP     Data Parameters
+ * @tparam PD     Prepared Data
+ * @tparam Q      Input Query
+ * @tparam P      Output Prediction
+ * @tparam A      Actual Value
  */
 class PJavaEngine[TD, DP, PD, Q, P, A](
     dataSourceClass: Class[_ <: PJavaDataSource[_ <: Params, DP, TD, Q, A]],


### PR DESCRIPTION
correct scaladoc tags to include @tparam instead of @param for documenting type parameters.
