### PR TITLE
Fix typos in documentation

### DIFF
--- a/core/src/main/scala/controller/DataSource.scala
+++ b/core/src/main/scala/controller/DataSource.scala
@@ -29,7 +29,7 @@ import scala.reflect._
   * that can fit within a single machine.
   *
   * @tparam TD Training data class.
-  * @tparam EI Evalution Info class.
+  * @tparam EI Evaluation Info class.
   * @tparam Q Input query class.
   * @tparam A Actual value class.
   * @group Data Source
@@ -60,7 +60,7 @@ abstract class LDataSource[
 
   /** Implement this method to return one set of test data (
     * a sequence of query and actual value pairs) from a data source.
-    * Should also implement readTraining to return correponding training data.
+    * Should also implement readTraining to return corresponding training data.
     */
   def readTest(): (EI, Seq[(Q, A)]) =
     (null.asInstanceOf[EI], Seq.empty[(Q, A)])
@@ -83,7 +83,7 @@ abstract class LDataSource[
   * on a cluster, to return data that is distributed across a cluster.
   *
   * @tparam TD Training data class.
-  * @tparam EI Evalution Info class.
+  * @tparam EI Evaluation Info class.
   * @tparam Q Input query class.
   * @tparam A Actual value class.
   * @group Data Source
@@ -105,7 +105,7 @@ abstract class PDataSource[TD, EI, Q, A]
 
   /** Implement this method to return one set of test data (
     * a sequence of query and actual value pairs) from a data source.
-    * Should also implement readTraining to return correponding training data.
+    * Should also implement readTraining to return corresponding training data.
     */
   def readTest(sc: SparkContext): (EI, RDD[(Q, A)]) =
     (null.asInstanceOf[EI], sc.parallelize(Seq.empty[(Q, A)]))

--- a/core/src/main/scala/controller/Engine.scala
+++ b/core/src/main/scala/controller/Engine.scala
@@ -80,7 +80,7 @@ class Engine[TD, EI, PD, Q, P, A](
       Map("" -> servingClass)
     )
 
-  /** Returns a new Engine instnace. Mimmic case class's copy method behavior.
+  /** Returns a new Engine instance. Mimic case class's copy method behavior.
     */
   def copy(
     dataSourceClassMap: Map[String, Class[_ <: BaseDataSource[TD, EI, Q, A]]]
@@ -172,8 +172,8 @@ class EngineParams(
 
 object EngineParams {
   /** Create EngineParams
-    * @param dataSourceName Data Soure name
-    * @param dataSourceParams Data Soure parameters
+    * @param dataSourceName Data Source name
+    * @param dataSourceParams Data Source parameters
     * @param preparatorName Preparator name
     * @param preparatorParams Preparator parameters
     * @param algorithmParamsList List of algorithm name-parameter pairs.
@@ -204,12 +204,11 @@ object EngineParams {
   *
   * @tparam TD Training data class.
   * @tparam EI Evaluation info class.
-  * @tparam PD Prepared data class.
   * @tparam Q Input query class.
   * @tparam P Output prediction class.
   * @tparam A Actual value class.
   * @param dataSourceClass Data source class.
-  * @param algorithmClassMap Map of algorithm names to classes.
+  * @param algorithmClass of algorithm names to classes.
   * @group Engine
   */
 class SimpleEngine[TD, EI, Q, P, A](
@@ -224,7 +223,7 @@ class SimpleEngine[TD, EI, Q, P, A](
 /** This shorthand class serves the `SimpleEngine` class.
   *
   * @param dataSourceParams Data source parameters.
-  * @param algorithmParamsList List of algorithm name-parameter pairs.
+  * @param algorithmParams List of algorithm name-parameter pairs.
   * @group Engine
   */
 class SimpleEngineParams(
@@ -244,7 +243,7 @@ trait IEngineFactory {
   /** Creates an instance of an [[Engine]]. */
   def apply(): Engine[_, _, _, _, _, _]
 
-  /** Override this method to programatically return engine parameters. */
+  /** Override this method to programmatically return engine parameters. */
   def engineParams(key: String): EngineParams = EngineParams()
 }
 

--- a/core/src/main/scala/controller/Evaluator.scala
+++ b/core/src/main/scala/controller/Evaluator.scala
@@ -29,7 +29,7 @@ import scala.reflect.runtime.universe._
   * Evaluator compare predicted result with actual known values and produce numerical
   * comparisons.
   *
-  * @tparam PD Prepared data class.
+  * @tparam DP Prepared data class.
   * @tparam Q Input query class.
   * @tparam P Output prediction class.
   * @tparam A Actual value class.

--- a/core/src/main/scala/controller/Workflow.scala
+++ b/core/src/main/scala/controller/Workflow.scala
@@ -58,7 +58,7 @@ case class WorkflowParams(
 object Workflow {
   /** Creates a workflow that runs an engine.
     *
-    * @tparam EI Evalution info class.
+    * @tparam EI Evaluation info class.
     * @tparam TD Training data class.
     * @tparam PD Prepared data class.
     * @tparam Q Input query class.
@@ -102,7 +102,7 @@ object Workflow {
 
   /** Creates a workflow that runs a collection of engine components.
     *
-    * @tparam EI Evalution info class.
+    * @tparam EI Evaluation info class.
     * @tparam TD Training data class.
     * @tparam PD Prepared data class.
     * @tparam Q Input query class.

--- a/core/src/main/scala/controller/java/JavaDataSource.scala
+++ b/core/src/main/scala/controller/java/JavaDataSource.scala
@@ -65,7 +65,7 @@ abstract class LJavaDataSource[TD, EI, Q, A]
 
   /** Implement this method to return one set of test data (
     * an Iterable of query and actual value pairs) from a data source.
-    * Should also implement readTraining to return correponding training data.
+    * Should also implement readTraining to return corresponding training data.
     */
   def readTest(): Tuple2[EI, JIterable[Tuple2[Q, A]]] =
     (null.asInstanceOf[EI], JCollections.emptyList())

--- a/core/src/main/scala/core/BasePreparator.scala
+++ b/core/src/main/scala/core/BasePreparator.scala
@@ -20,7 +20,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._
 import scala.reflect._
 
-// Probably will add an extra parameter for adhoc json formatter.
+// Probably will add an extra parameter for ad hoc json formatter.
 abstract class BasePreparator[TD, PD]
   extends AbstractDoer {
   def prepareBase(sc: SparkContext, td: TD): PD

--- a/core/src/main/scala/workflow/Workflow.scala
+++ b/core/src/main/scala/workflow/Workflow.scala
@@ -149,7 +149,7 @@ extends Serializable {
     val iQuery: RDD[(QI, Q)] = iInput.map(e => (e._1, e._2._1))
     val sc = input.context
 
-    // Each algo/model is run independely.
+    // Each algo/model is run independently.
     val iAlgoPredictionSeq: Seq[RDD[(QI, (AI, P))]] = models
       .zipWithIndex
       .map { case (model, ai) => {
@@ -267,8 +267,8 @@ object CoreWorkflow {
   // ***Do not directly call*** any "Typeless" method unless you know exactly
   // what you are doing.
 
-  // When engine and evaluator are instantiated direcly from CLI, the compiler has
-  // no way to know their actual type parameter during compile time. To rememdy
+  // When engine and evaluator are instantiated directly from CLI, the compiler has
+  // no way to know their actual type parameter during compile time. To remedy
   // this restriction, we have to let engine and evaluator to be casted to their
   // own type parameters, and force cast their type during runtime.
   // In particular, evaluator needs to be instantiated to keep scala compiler
@@ -309,7 +309,7 @@ object CoreWorkflow {
   }
 
   // yipjustin: The parameter list has more than 80 columns. But I cannot find a
-  // way to spread it to multiple lines while presving the reability.
+  // way to spread it to multiple lines while preserving the readability.
   def runTypeless[
       EI, TD, PD, Q, P, A,
       MEI, MQ, MP, MA,
@@ -775,7 +775,7 @@ object CoreWorkflow {
 
   /** Extract model for persistent layer.
     *
-    * PredictionIO presist models for future use.  It allows custom
+    * PredictionIO persist models for future use.  It allows custom
     * implementation for persisting models. You need to implement the
     * [[io.prediction.controller.IPersistentModel]] interface. This method
     * traverses all models in the workflow. If the model is a

--- a/core/src/main/scala/workflow/WorkflowUtils.scala
+++ b/core/src/main/scala/workflow/WorkflowUtils.scala
@@ -190,7 +190,7 @@ object WorkflowUtils extends Logging {
     runner.start
   }
 
-  // Extract debug string by recusively traversing the data.
+  // Extract debug string by recursively traversing the data.
   def debugString[D](data: D): String = {
     val s: String = data match {
       case rdd: RDD[_] => {

--- a/data/src/main/scala/storage/AccessKeys.scala
+++ b/data/src/main/scala/storage/AccessKeys.scala
@@ -30,7 +30,7 @@ private[prediction] case class AccessKey(
   events: Seq[String])
 
 /**
- * Base trait for implementations that interact with AcessKeys in the backend
+ * Base trait for implementations that interact with AccessKeys in the backend
  * data store.
  */
 private[prediction] trait AccessKeys {

--- a/data/src/main/scala/storage/DataMap.scala
+++ b/data/src/main/scala/storage/DataMap.scala
@@ -136,7 +136,7 @@ case class DataMap (
 
   /** Converts this DataMap to a JObject.
     *
-    * @return the JObject initizalized by this DataMap.
+    * @return the JObject initialized by this DataMap.
     */
   def toJObject(): JObject = JObject(toList())
 
@@ -151,7 +151,7 @@ object DataMap {
 
   /** Create an DataMap from a JObject
     * @param jObj JObject
-    * @return a new DataMap initlized by a JObject
+    * @return a new DataMap initialized by a JObject
     */
   def apply(jObj: JObject): DataMap = {
     if (jObj == null) DataMap() else DataMap(jObj.obj.toMap)

--- a/data/src/main/scala/storage/Event.scala
+++ b/data/src/main/scala/storage/Event.scala
@@ -27,7 +27,7 @@ import org.joda.time.DateTimeZone
   * @param entityId ID of the entity associated with this event.
   * @param targetEntityType Type of the target entity associated with this
   *                         event.
-  * @param targetEntityId ID of the target entity asssociated with this event.
+  * @param targetEntityId ID of the target entity associated with this event.
   * @param properties Properties associated with this event.
   * @param eventTime Time of the happening of this event.
   * @param tags Tags of this event.

--- a/data/src/main/scala/storage/EventJson4sSupport.scala
+++ b/data/src/main/scala/storage/EventJson4sSupport.scala
@@ -32,7 +32,7 @@ private[prediction] object EventJson4sSupport {
   def readJson: PartialFunction[JValue, Event] = {
     case JObject(x) => {
       val fields = new DataMap(x.toMap)
-      // use get() if requried in json
+      // use get() if required in json
       // use getOpt() if not required in json
       try {
         val event = fields.get[String]("event")

--- a/data/src/main/scala/storage/LEvents.scala
+++ b/data/src/main/scala/storage/LEvents.scala
@@ -31,7 +31,7 @@ private[prediction] trait LEvents {
   val defaultTimeout = Duration(60, "seconds")
 
   /** Initialize Event Store for the appId.
-   * initailization routine to be called when app is first created.
+   * initialization routine to be called when app is first created.
    * return true if succeed or false if fail.
    */
   def init(appId: Int): Boolean = {

--- a/data/src/main/scala/storage/PEventAggregator.scala
+++ b/data/src/main/scala/storage/PEventAggregator.scala
@@ -168,7 +168,7 @@ private[prediction] object PEventAggregator {
     eventsRDD
       .map( e => (e.entityId, EventOp(e) ))
       .aggregateByKey[EventOp](EventOp())(
-        // within same parition
+        // within same partition
         seqOp = { case (u, v) => u ++ v },
         // across partition
         combOp = { case (accu, u) => accu ++ u }

--- a/data/src/main/scala/storage/hbase/HBEventsUtil.scala
+++ b/data/src/main/scala/storage/hbase/HBEventsUtil.scala
@@ -43,14 +43,14 @@ import java.security.MessageDigest
 
 import java.util.UUID
 
-/* common utility function for acessing EventsStore in HBase */
+/* common utility function for accessing EventsStore in HBase */
 object HBEventsUtil {
 
   implicit val formats = DefaultFormats
 
   def tableName(namespace: String, appId: Int) = s"${namespace}:events_${appId}"
 
-  // column nams for "e" column family
+  // column names for "e" column family
   val colNames: Map[String, Array[Byte]] = Map(
     "event" -> "e",
     "entityType" -> "ety",
@@ -67,7 +67,7 @@ object HBEventsUtil {
 
   def hash(entityType: String, entityId: String): Array[Byte] = {
     val s = entityType + "-" + entityId
-    // get a new MessgaeDigest object each time for thread-safe
+    // get a new MessageDigest object each time for thread-safe
     val md5 = MessageDigest.getInstance("MD5")
     md5.digest(Bytes.toBytes(s))
   }
@@ -94,7 +94,7 @@ object HBEventsUtil {
       millis: Long,
       uuidLow: Long): RowKey = {
         // add UUID least significant bits for multiple actions at the same time
-        // (UUID's most significantbits are actually timestamp,
+        // (UUID's most significant bits are actually timestamp,
         // use eventTime instead).
         val b = hash(entityType, entityId) ++
           Bytes.toBytes(millis) ++ Bytes.toBytes(uuidLow)
@@ -136,7 +136,7 @@ object HBEventsUtil {
   }
 
   def eventToPut(event: Event, appId: Int): (Put, RowKey) = {
-    // TOOD: use real UUID. not psuedo random
+    // TOOD: use real UUID. not pseudo random
     val uuidLow: Long = UUID.randomUUID().getLeastSignificantBits
     val rowKey = RowKey(
       entityType = event.entityType,

--- a/data/src/main/scala/storage/hbase/PIOHBaseUtil.scala
+++ b/data/src/main/scala/storage/hbase/PIOHBaseUtil.scala
@@ -16,7 +16,7 @@
 package org.apache.hadoop.hbase.mapreduce
 
 /* Pretends to be hbase.mapreduce package in order to expose its
- * Package-accessisble only static function convertScanToString()
+ * Package-accessible only static function convertScanToString()
  */
 
 import org.apache.hadoop.hbase.client.Scan

--- a/data/src/main/scala/storage/hbase/upgrade/HB_0_8_0.scala
+++ b/data/src/main/scala/storage/hbase/upgrade/HB_0_8_0.scala
@@ -60,7 +60,7 @@ object HB_0_8_0 {
   ) {
     lazy val toBytes: Array[Byte] = {
       // add UUID least significant bits for multiple actions at the same time
-      // (UUID's most significantbits are actually timestamp,
+      // (UUID's most significant bits are actually timestamp,
       // use eventTime instead).
       Bytes.toBytes(appId) ++ Bytes.toBytes(millis) ++ Bytes.toBytes(uuidLow)
     }

--- a/data/src/main/scala/view/LBatchView.scala
+++ b/data/src/main/scala/view/LBatchView.scala
@@ -138,7 +138,7 @@ class LBatchView(
 
   @transient lazy val events: EventSeq = new EventSeq(_events)
 
-  /* Aggreate event data
+  /* Aggregate event data
    *
    * @param entityType only aggregate event with entityType
    * @param startTimeOpt if specified, only aggregate event after (inclusive)

--- a/data/src/main/scala/view/PBatchView.scala
+++ b/data/src/main/scala/view/PBatchView.scala
@@ -196,7 +196,7 @@ class PBatchView(
         (EventValidation.isSpecialEvents(e.event))) )
       .map( e => (e.entityId, EventOp(e) ))
       .aggregateByKey[EventOp](EventOp())(
-        // within same parition
+        // within same partition
         seqOp = { case (u, v) => u ++ v },
         // across partition
         combOp = { case (accu, u) => accu ++ u }

--- a/engines/src/main/scala/base/EventsDataSource.scala
+++ b/engines/src/main/scala/base/EventsDataSource.scala
@@ -126,7 +126,7 @@ class EventsDataSource[DP: ClassTag, Q, A](
           items = HashMap[Int, ItemTD]() ++ items,
           u2iActions = trainActions.toList)
 
-        // Use [firstTrain + idx * duration, firstTraing + (idx+1) * duration)
+        // Use [firstTrain + idx * duration, firstTraining + (idx+1) * duration)
         // as testing
         val evalActions = extractActions(
           uid2ui,

--- a/engines/src/main/scala/base/PEventsDataSource.scala
+++ b/engines/src/main/scala/base/PEventsDataSource.scala
@@ -87,7 +87,7 @@ class PEventsDataSource[DP: ClassTag, Q, A](
           items = items,
           u2iActions = trainActions)
 
-        // Use [firstTrain + idx * duration, firstTraing + (idx+1) * duration)
+        // Use [firstTrain + idx * duration, firstTraining + (idx+1) * duration)
         // as testing
         val evalActions = extractActions(
           batchView,
@@ -129,7 +129,7 @@ class PEventsDataSource[DP: ClassTag, Q, A](
     .map { case (entityId, dataMap) =>
       (entityId, new UserTD(uid = entityId))
     }
-    .zipWithUniqueId // theis Long id may exist gaps but no need spark job
+    .zipWithUniqueId // this Long id may exist gaps but no need spark job
     // TODO: may need to change local EventDataSource to use Long.
     // Force to Int now so can re-use same userTD, itemTD, and ratingTD
     .mapValues( _.toInt )

--- a/engines/src/main/scala/base/Preparator.scala
+++ b/engines/src/main/scala/base/Preparator.scala
@@ -31,7 +31,7 @@ object Preparator {
   // Maps actions to a numerical rating with the following logic:
   // If action belongs to actionMap, then it looks at the map value. If it is
   // defined, use it; otherwise, use the numerical value v.
-  // Last, if above method fails to define a numercical rating, default is used.
+  // Last, if above method fails to define a numerical rating, default is used.
   def action2rating(action: String, v: Option[Int],
     actionsMap: Map[String, Option[Int]], default: Int): Int = {
     actionsMap(action).getOrElse(v.getOrElse(default))
@@ -44,7 +44,7 @@ object Preparator {
 
   /*
   // Return a boolean value. Usually used by metrics to define "good" rating.
-  // Logic is simliar to action2rating, except that a threshold will be used for
+  // Logic is similar to action2rating, except that a threshold will be used for
   // comparing numerical value.
   def action2boolean(action: String, v: Option[Int],
     actionsMap: Map[String, Option[Boolean]], 

--- a/engines/src/main/scala/base/mahout/AbstractNCItemBasedAlgorithm.scala
+++ b/engines/src/main/scala/base/mahout/AbstractNCItemBasedAlgorithm.scala
@@ -96,7 +96,7 @@ class NCItemBasedAlgorithmModel(
   @transient lazy val itemsIndexMap: Map[String, Long] = validItemsMap.map {
       case (index, item) => (item.id, index) }
 
-  // TODO: refactor to suppport other types of Recommender (eg. SVD)
+  // TODO: refactor to support other types of Recommender (eg. SVD)
   private def buildRecommender(): ItemBasedRecommender = {
     logger.info("Building recommender...")
     val weightedParam: Weighting = if (params.weighted) Weighting.WEIGHTED
@@ -164,7 +164,7 @@ abstract class AbstractNCItemBasedAlgorithm[Q : Manifest, P](
         (r.uindex, r.iindex, r.rating.toFloat, r.t) })
     }
 
-    // don't have seperated seen actions data for now
+    // don't have separated seen actions data for now
     val seenDataModel: DataModel = preparedData.seenU2IActions.map {
       seenU2IActions =>
         if (seenU2IActions.isEmpty)

--- a/engines/src/main/scala/itemrank/EventsDataSource.scala
+++ b/engines/src/main/scala/itemrank/EventsDataSource.scala
@@ -45,7 +45,7 @@ class EventsDataSource(dsp: EventsDataSourceParams)
     * It constructs a list of Query-Actual pair using the list of actions.
     * For each user in the list, it creates a Query instance using all items in
     * actions, and creates an Actual instance with all actions associated with
-    * the user. Note that it is the metrics job to decide how to interprete the
+    * the user. Note that it is the metrics job to decide how to interpret the
     * semantics of the actions.
     */
   override def generateQueryActualSeq(

--- a/engines/src/main/scala/itemrank/ItemRankDetailedEvaluator.scala
+++ b/engines/src/main/scala/itemrank/ItemRankDetailedEvaluator.scala
@@ -97,7 +97,7 @@ class ItemRankMAP(val k: Int, val metricsParams: DetailedEvaluatorParams)
   // metric
   private def averagePrecisionAtK[T](k: Int, p: Seq[T], r: Set[T]): Double = {
     // supposedly the predictedItems.size should match k
-    // NOTE: what if predictedItems is less than k? use the avaiable items as k.
+    // NOTE: what if predictedItems is less than k? use the available items as k.
     val n = scala.math.min(p.size, k)
 
     // find if each element in the predictedItems is one of the relevant items
@@ -189,7 +189,7 @@ class ItemRankDetailedEvaluator(params: DetailedEvaluatorParams)
     )
   }
 
-  // calcualte MAP at k
+  // calculate MAP at k
   override def evaluateSet(dataParams: HasName,
     metricUnits: Seq[EvaluationUnit]): Seq[EvaluationUnit] = metricUnits
 

--- a/engines/src/main/scala/util/Util.scala
+++ b/engines/src/main/scala/util/Util.scala
@@ -137,7 +137,7 @@ object MathUtil {
   /** Average precision at k */
   def averagePrecisionAtK[T](k: Int, p: Seq[T], r: Set[T]): Double = {
     // supposedly the predictedItems.size should match k
-    // NOTE: what if predictedItems is less than k? use the avaiable items as k.
+    // NOTE: what if predictedItems is less than k? use the available items as k.
     val n = scala.math.min(p.size, k)
 
     // find if each element in the predictedItems is one of the relevant items


### PR DESCRIPTION
Fix typos and commonly misspelled words in method / inline documentation