### PR TITLE
confirm delete existing tmp file before download

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -221,6 +221,14 @@ echo "JAVA_HOME is now set to: $JAVA_HOME"
 # PredictionIO
 echo -e "\033[1;36mStarting PredictionIO setup in:\033[0m $pio_dir"
 cd $TEMP_DIR
+
+# delete existing tmp file before download again
+if [[ -e  $PIO_FILE ]]; then
+  if confirm "Delete existing temporary file?"; then
+    rm $PIO_FILE
+  fi
+fi
+
 if [[ ! -e $PIO_FILE ]]; then
   echo "Downloading PredictionIO..."
   curl -O https://d8k1yxp8elc6b.cloudfront.net/$PIO_FILE


### PR DESCRIPTION
I encountered an error before where interrupting the tar download would cause subsequent install attempts to fail. Deleting the tmp file would make sure it gets download again.