### PR TITLE
Install from source build and config instruction tweaks

### DIFF
--- a/docs/manual/source/install/install-sourcecode.html.md.erb
+++ b/docs/manual/source/install/install-sourcecode.html.md.erb
@@ -68,10 +68,13 @@ Elasticsearch.
 
 If you are not using the default setting at localhost. You may change the following in ```conf/pio-env.sh``` to fit your setup.
 
+Make sure to set PIO_STORAGE_SOURCES_ELASTICSEARCH_HOME
+
 ```
 PIO_STORAGE_SOURCES_ELASTICSEARCH_TYPE=elasticsearch
 PIO_STORAGE_SOURCES_ELASTICSEARCH_HOSTS=localhost
 PIO_STORAGE_SOURCES_ELASTICSEARCH_PORTS=9300
+PIO_STORAGE_SOURCES_ELASTICSEARCH_HOME=/path/to/elasticsearch
 ```
 
 #### <a name="hbase"></a>HBase Setup
@@ -114,6 +117,13 @@ would be
 ```
 export JAVA_HOME=`/usr/libexec/java_home -v 1.7`
 ```
+
+Navigate to your pio root and edit ```conf/pio-env.sh``` add:
+
+```
+PIO_STORAGE_SOURCES_HBASE_HOME=/path/to/hbase
+```
+
 
 <%= partial 'shared/install/dependent_services' %>
 

--- a/docs/manual/source/install/install-sourcecode.html.md.erb
+++ b/docs/manual/source/install/install-sourcecode.html.md.erb
@@ -95,18 +95,17 @@ sample minimal configuration.
 
 > For production deployment, run a fully distributed HBase configuration.
 
-Edit `conf/hbase-site.xml` and put the following in. You may replace `/home/abc`
-with your own home directory.
+Edit `/path/to/hbase/conf/hbase-site.xml` and configure the local **data** directories for HBase and ZooKeeper. These directories should be empty the first time you launch pio.
 
 ```
 <configuration>
   <property>
     <name>hbase.rootdir</name>
-    <value>file:///home/abc/hbase</value>
+    <value>file:///path/to/hbase-data-dir</value>
   </property>
   <property>
     <name>hbase.zookeeper.property.dataDir</name>
-    <value>/home/abc/zookeeper</value>
+    <value>/path/to/zookeeper-data-dir</value>
   </property>
 </configuration>
 ```
@@ -118,10 +117,11 @@ would be
 export JAVA_HOME=`/usr/libexec/java_home -v 1.7`
 ```
 
-Navigate to your pio root and edit ```conf/pio-env.sh``` add the path to hbase's root directory and config:
+Navigate back to your pio root and edit ```conf/pio-env.sh``` add the path to hbase's root and config directories:
 
 ```
 HBASE_CONF_DIR=/path/to/hbase/conf
+...
 PIO_STORAGE_SOURCES_HBASE_HOME=/path/to/hbase
 ```
 

--- a/docs/manual/source/install/install-sourcecode.html.md.erb
+++ b/docs/manual/source/install/install-sourcecode.html.md.erb
@@ -118,9 +118,10 @@ would be
 export JAVA_HOME=`/usr/libexec/java_home -v 1.7`
 ```
 
-Navigate to your pio root and edit ```conf/pio-env.sh``` add:
+Navigate to your pio root and edit ```conf/pio-env.sh``` add the path to hbase's root directory and config:
 
 ```
+HBASE_CONF_DIR=/path/to/hbase/conf
 PIO_STORAGE_SOURCES_HBASE_HOME=/path/to/hbase
 ```
 


### PR DESCRIPTION
BTW why are their both hbase conf and root variable in pio-env.sh? Seems like conf can be derived from the root. Conf should be kept with the HBase installation directory don't you think? That way the binary and config can be changed independent of PIO. HBase can then be treated as independent of PIO by experts and still works when bundled.

Following the HBase install quickstart leads one to believe the conf is with HBase, not in pio/conf. So there is confusion where you tell the user to edit the hbase/conf but the edits are ignored by pio-start-all since it finds the hbase conf at pio/conf.

The instructions will create a working installation but this seems a bit inconsistent.

