### PR TITLE
[pio-shell] interactive PIO shell

### DIFF
--- a/bin/pio-shell
+++ b/bin/pio-shell
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Copyright 2015 TappingStone, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+  #
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export PIO_HOME="$(cd `dirname $0`/..; pwd)"
+. $PIO_HOME/bin/load-pio-env.sh
+
+if [[ "$@" == "--with-spark" ]]
+then
+  echo "Starting the PIO shell with the Apache Spark Shell."
+  # compute the $ASSEMPLY_JAR, the location of the assemply jar, with
+  # bin/compute-classpath.sh
+  . $PIO_HOME/bin/compute-classpath.sh
+  $SPARK_HOME/bin/spark-shell --jars $ASSEMBLY_JAR 
+else
+  echo "Starting the PIO shell without Apache Spark."
+  echo "If you need the Apache Spark library, run 'pio-shell --with-spark'."
+  cd $PIO_HOME
+  ./sbt/sbt console
+fi
+


### PR DESCRIPTION
Add a script to start the PIO shell. There are two modes to start the shell.

1) `pio-shell`:
Start the pio shell by sbt. It includes the pio library.

2) `pio-shell --with-spark`
Start the pio shell by spark-shell. It includes both pio library
and the Apache Spark. It requries the Apache Spark setup and also takes
longer to start.

For example, https://gist.github.com/whhone/016088d3c3dfd73aaf9f