### PR TITLE
Add support for serializing synchronized collections

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -22,8 +22,19 @@ This product includes software, code and tests from the following projects:
   - Apache Mahout - http://mahout.apache.org/ - Copyright © 2014 The Apache Software Foundation
   - Apache Spark - http://spark.apache.org/ - Copyright © 2014 The Apache Software Foundation
   - Casbah - http://mongodb.github.io/casbah/ - Copyright © 2010 MongoDB, Inc.
-  - Chill - https://engineering.twitter.com/opensource/projects/chill - Copyright © 2012 Twitter, Inc.  - Elasticsearch - http://www.elasticsearch.org/ - Copyright © 2014 Elasticsearch
-  - Grizzled-SLF4J - http://software.clapper.org/grizzled-slf4j/ - Copyright © 2010 Brian M. Clapper  - Gson - https://code.google.com/p/google-gson/ - Copyright © 2010 Google  - Guava - https://code.google.com/p/guava-libraries/ - Copyright © 2014 Google  - Json4s - http://json4s.org/ - Copyright © 2014 json4s.org  - Saddle - http://saddle.github.io/doc/ - © Copyright 2013, The Saddle Development Team
+  - Chill - https://engineering.twitter.com/opensource/projects/chill - Copyright © 2012 Twitter, Inc.
+  - Elasticsearch - http://www.elasticsearch.org/ - Copyright © 2014 Elasticsearch
+  - Grizzled-SLF4J - http://software.clapper.org/grizzled-slf4j/ - Copyright © 2010 Brian M. Clapper
+  - Gson - https://code.google.com/p/google-gson/ - Copyright © 2010 Google
+  - Guava - https://code.google.com/p/guava-libraries/ - Copyright © 2014 Google
+  - Json4s - http://json4s.org/ - Copyright © 2014 json4s.org
+  - Kryo Serializers - https://github.com/magro/kryo-serializers - Copyright 2010 Martin Grotzke
+  - Saddle - http://saddle.github.io/doc/ - © Copyright 2013, The Saddle Development Team
   - scalaj-http - https://github.com/scalaj/scalaj-http - © Copyright 2014 scalaj.org
   - ScalaNLP - http://www.scalanlp.org/ - Copyright © 2014 David Hall
-  - ScalaTest - http://www.scalatest.org/ - Copyright © 2009-2013 Artima, Inc.  - scopt - https://github.com/scopt/scopt - Copyright © 2010 Google  - semverfi - https://github.com/softprops/semverfi - Copyright © 2012 Doug Tangren  - specs2 - http://etorreborre.github.io/specs2/ - Copyright © 2014 Eric Torreborre  - spray - http://spray.io/ - Copyright © 2014 Typesafe, Inc.  - typetools - https://github.com/jhalterman/typetools/ - Copyright © 2010-2013 Jonathan Halterman
+  - ScalaTest - http://www.scalatest.org/ - Copyright © 2009-2013 Artima, Inc.
+  - scopt - https://github.com/scopt/scopt - Copyright © 2010 Google
+  - semverfi - https://github.com/softprops/semverfi - Copyright © 2012 Doug Tangren
+  - specs2 - http://etorreborre.github.io/specs2/ - Copyright © 2014 Eric Torreborre
+  - spray - http://spray.io/ - Copyright © 2014 Typesafe, Inc.
+  - typetools - https://github.com/jhalterman/typetools/ - Copyright © 2010-2013 Jonathan Halterman

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -15,25 +15,26 @@
 name := "core"
 
 libraryDependencies ++= Seq(
-  "com.github.scopt"       %% "scopt"           % "3.2.0",
-  "com.google.code.gson"    % "gson"            % "2.2.4",
-  "com.google.guava"        % "guava"           % "18.0",
-  "com.twitter"            %% "chill"           % "0.5.0"
+  "com.github.scopt"       %% "scopt"            % "3.2.0",
+  "com.google.code.gson"    % "gson"             % "2.2.4",
+  "com.google.guava"        % "guava"            % "18.0",
+  "com.twitter"            %% "chill"            % "0.5.0"
     exclude("com.esotericsoftware.minlog", "minlog"),
-  "com.twitter"            %% "chill-bijection" % "0.5.0",
-  "commons-io"              % "commons-io"      % "2.4",
-  "io.spray"               %% "spray-can"       % "1.3.2",
-  "io.spray"               %% "spray-routing"   % "1.3.2",
-  "net.jodah"               % "typetools"       % "0.3.1",
-  "org.apache.spark"       %% "spark-core"      % sparkVersion.value % "provided",
-  "org.clapper"            %% "grizzled-slf4j"  % "1.0.2",
-  "org.elasticsearch"       % "elasticsearch"   % elasticsearchVersion.value,
-  "org.json4s"             %% "json4s-native"   % json4sVersion.value,
-  "org.json4s"             %% "json4s-ext"      % json4sVersion.value,
-  "org.scalaj"             %% "scalaj-http"     % "1.1.0",
-  "org.scalatest"          %% "scalatest"       % "2.1.6" % "test",
-  "org.slf4j"               % "slf4j-log4j12"   % "1.7.7",
-  "org.specs2"             %% "specs2"          % "2.3.13" % "test")
+  "com.twitter"            %% "chill-bijection"  % "0.5.0",
+  "de.javakaffee"           % "kryo-serializers" % "0.28",
+  "commons-io"              % "commons-io"       % "2.4",
+  "io.spray"               %% "spray-can"        % "1.3.2",
+  "io.spray"               %% "spray-routing"    % "1.3.2",
+  "net.jodah"               % "typetools"        % "0.3.1",
+  "org.apache.spark"       %% "spark-core"       % sparkVersion.value % "provided",
+  "org.clapper"            %% "grizzled-slf4j"   % "1.0.2",
+  "org.elasticsearch"       % "elasticsearch"    % elasticsearchVersion.value,
+  "org.json4s"             %% "json4s-native"    % json4sVersion.value,
+  "org.json4s"             %% "json4s-ext"       % json4sVersion.value,
+  "org.scalaj"             %% "scalaj-http"      % "1.1.0",
+  "org.scalatest"          %% "scalatest"        % "2.1.6" % "test",
+  "org.slf4j"               % "slf4j-log4j12"    % "1.7.7",
+  "org.specs2"             %% "specs2"           % "2.3.13" % "test")
 
 net.virtualvoid.sbt.graph.Plugin.graphSettings
 

--- a/core/src/main/scala/io/prediction/controller/Utils.scala
+++ b/core/src/main/scala/io/prediction/controller/Utils.scala
@@ -17,7 +17,6 @@ package io.prediction.controller
 
 import io.prediction.workflow.KryoInstantiator
 
-import com.twitter.chill.KryoInjection
 import org.json4s._
 import org.json4s.ext.JodaTimeSerializers
 
@@ -42,12 +41,12 @@ object Utils {
     * @param model Model object.
     */
   def save(id: String, model: Any): Unit = {
-    val tmpdir = sys.env.get("PIO_FS_TMPDIR").getOrElse(
-      System.getProperty("java.io.tmpdir"))
+    val tmpdir = sys.env.getOrElse("PIO_FS_TMPDIR", System.getProperty("java.io.tmpdir"))
     val modelFile = tmpdir + File.separator + id
     (new File(tmpdir)).mkdirs
     val fos = new FileOutputStream(modelFile)
-    fos.write(KryoInjection(model))
+    val kryo = KryoInstantiator.newKryoInjection
+    fos.write(kryo(model))
     fos.close
   }
 
@@ -59,12 +58,10 @@ object Utils {
     * @param id Used as the filename of the file.
     */
   def load(id: String): Any = {
-    val tmpdir = sys.env.get("PIO_FS_TMPDIR").getOrElse(
-      System.getProperty("java.io.tmpdir"))
+    val tmpdir = sys.env.getOrElse("PIO_FS_TMPDIR", System.getProperty("java.io.tmpdir"))
     val modelFile = tmpdir + File.separator + id
     val src = Source.fromFile(modelFile)(scala.io.Codec.ISO8859)
-    val kryoInstantiator = new KryoInstantiator(getClass.getClassLoader)
-    val kryo = KryoInjection.instance(kryoInstantiator)
+    val kryo = KryoInstantiator.newKryoInjection
     val m = kryo.invert(src.map(_.toByte).toArray).get
     src.close
     m

--- a/core/src/main/scala/io/prediction/workflow/CoreWorkflow.scala
+++ b/core/src/main/scala/io/prediction/workflow/CoreWorkflow.scala
@@ -15,9 +15,6 @@
 
 package io.prediction.workflow
 
-import com.github.nscala_time.time.Imports.DateTime
-import com.twitter.chill.KryoInjection
-import grizzled.slf4j.Logger
 import io.prediction.controller.EngineParams
 import io.prediction.controller.Evaluation
 import io.prediction.controller.WorkflowParams
@@ -28,6 +25,9 @@ import io.prediction.data.storage.EngineInstance
 import io.prediction.data.storage.EvaluationInstance
 import io.prediction.data.storage.Model
 import io.prediction.data.storage.Storage
+
+import com.github.nscala_time.time.Imports.DateTime
+import grizzled.slf4j.Logger
 
 import scala.language.existentials
 
@@ -67,10 +67,12 @@ object CoreWorkflow {
 
       val instanceId = Storage.getMetaDataEngineInstances
 
+      val kryo = KryoInstantiator.newKryoInjection
+      
       logger.info("Inserting persistent model")
       Storage.getModelDataModels.insert(Model(
         id = engineInstance.id,
-        models = KryoInjection(models)))
+        models = kryo(models)))
 
       logger.info("Updating engine instance")
       val engineInstances = Storage.getMetaDataEngineInstances


### PR DESCRIPTION
Adds support for serializing via kyro Java synchronized Collections and Maps created with Collections.synchronized*.  To achieve this I used de.javakaffee.kryo-serializers. This project also contains serializers for many other types and they can be easily added in the future if needed.