### PR TITLE
Update install-linux.html.md.erb

### DIFF
--- a/docs/manual/source/install/install-linux.html.md.erb
+++ b/docs/manual/source/install/install-linux.html.md.erb
@@ -128,6 +128,11 @@ For example:
 export JAVA_HOME=`/usr/lib/jvm/java-8-oracle/jre`
 ```
 
+For Mac users, use this instead:
+```
+export JAVA_HOME=`/usr/libexec/java_home -v 1.7`
+```
+
 In addition, you must set your environment variable `JAVA_HOME`.
 For example, in `/home/abc/.bashrc` add the following line:
 ```
@@ -137,3 +142,5 @@ export JAVA_HOME=`/usr/lib/jvm/java-8-oracle`
 <%= partial 'shared/install/dependent_services' %>
 
 Now you have installed everything you need!
+
+#### [Next: Recommendation Engine Quick Start](/templates/recommendation/quickstart/)

--- a/docs/manual/source/install/install-linux.html.md.erb
+++ b/docs/manual/source/install/install-linux.html.md.erb
@@ -10,54 +10,68 @@ NOTE: <span class="new">**Note:**</span> PredictionIO can now be installed with 
 The above script will complete the rest of the instructions on this page for you
 so you can skip them.
 
+
 ## Manual Install
 
 If you don't want to use the install script above, you can follow the steps
-below to setup PredictionIO and its dependencies.
+below to setup PredictionIO and its dependencies. In these instructions we will assume you are in
+your home directory. Whereever you see `/home/abc`, replace it with your own home directory.
+
+
+### Java
+
+Ensure you have an appropriate Java version installed:
+For example:
+```
+$ java -version
+java version "1.8.0_40"
+Java(TM) SE Runtime Environment (build 1.8.0_40-b25)
+Java HotSpot(TM) 64-Bit Server VM (build 25.40-b25, mixed mode)
+```
+
 
 ### Download PredictionIO
 
 Simply download PredictionIO's binary distribution and extract it.
-
 ```
 $ wget https://d8k1yxp8elc6b.cloudfront.net/PredictionIO-<%= data.versions.pio %>.tar.gz
 $ tar zxvf PredictionIO-<%= data.versions.pio %>.tar.gz
-$ cd PredictionIO-<%= data.versions.pio %>
 ```
 
-### Installing Dependencies
 
+### Installing Dependencies
 
 
 #### Spark Setup
 
 Apache Spark is the default processing engine for PredictionIO. Download [Apache
 Spark release 1.2.0 package hadoop2.4](http://spark.apache.org/downloads.html).
-Extract the file, and set the `SPARK_HOME` configuration in `conf/pio-env.sh` to
-the Spark directory.
-
+Extract the file, and set the `SPARK_HOME` configuration in `PredictionIO-<%= data.versions.pio %>/conf/pio-env.sh`.
 ```
 $ wget http://d3kbcqa49mib13.cloudfront.net/<%= data.versions.spark_download_filename %>.tgz
 $ tar zxvf <%= data.versions.spark_download_filename %>.tgz
 ```
 
-After that, edit `conf/pio-env.sh` in your PredictionIO installation directory.
-For example,
+After that, edit `PredictionIO-<%= data.versions.pio %>/conf/pio-env.sh`.
+```
+SPARK_HOME=/home/abc/<%= data.versions.spark_download_filename %>
+```
 
-```
-SPARK_HOME=/home/abc/Downloads/<%= data.versions.spark_download_filename %>
-```
 
 #### Elasticsearch Setup
 
 By default, PredictionIO uses Elasticsearch at localhost as the data store to
-store its metadata. Simply download and install
-[Elasticsearch](http://www.elasticsearch.org/), which looks like this:
-
+store its metadata. Download [Elasticsearch](http://www.elasticsearch.org/).
+Extract the file, and set the `PIO_STORAGE_SOURCES_ELASTICSEARCH_HOME` configuration
+in `PredictionIO-<%= data.versions.pio %>/conf/pio-env.sh`.
 ```
 $ wget https://download.elasticsearch.org/elasticsearch/elasticsearch/<%= data.versions.elasticsearch_download_filename %>.tar.gz
 $ tar zxvf <%= data.versions.elasticsearch_download_filename %>.tar.gz
-$ cd <%= data.versions.elasticsearch_download_filename %>
+```
+
+After that, edit `PredictionIO-<%= data.versions.pio %>/conf/pio-env.sh`.
+```
+PIO_STORAGE_SOURCES_ELASTICSEARCH_HOME=/home/abc/<%= data.versions.elasticsearch_download_filename %>
 ```
 
 If you are using a shared network, change the `network.host` line in
@@ -65,42 +79,41 @@ If you are using a shared network, change the `network.host` line in
 Elasticsearch looks for other machines on the network upon setup and you may run
 into weird errors if there are other machines that is also running
 Elasticsearch.
-
 If you are not using the default setting at localhost. You may change the
-following in `conf/pio-env.sh` to fit your setup.
-
+following in `PredictionIO-<%= data.versions.pio %>/conf/pio-env.sh` to fit your setup.
 ```
 PIO_STORAGE_SOURCES_ELASTICSEARCH_TYPE=elasticsearch
 PIO_STORAGE_SOURCES_ELASTICSEARCH_HOSTS=localhost
 PIO_STORAGE_SOURCES_ELASTICSEARCH_PORTS=9300
 ```
 
+
 #### HBase Setup<a class="anchor" name="hbase">&nbsp;</a>
 
 By default, PredictionIO's Data API uses HBase at localhost as the data store
-for event data.
-
+for event data. Download [HBase](http://hbase.apache.org/).
+Extract the file, and set the `PIO_STORAGE_SOURCES_HBASE_HOME` configuration in `PredictionIO-<%= data.versions.pio %>/conf/pio-env.sh`.
 ```
 $ wget http://archive.apache.org/dist/hbase/<%= data.versions.hbase_basename %>/<%= data.versions.hbase_basename %>-<%= data.versions.hbase_variant %>.tar.gz
 $ tar zxvf <%= data.versions.hbase_basename %>-<%= data.versions.hbase_variant %>.tar.gz
-$ cd <%= data.versions.hbase_basename %>-<%= data.versions.hbase_dir_suffix %>
+```
+
+After that, edit `PredictionIO-<%= data.versions.pio %>/conf/pio-env.sh`.
+```
+PIO_STORAGE_SOURCES_HBASE_HOME=/home/abc/<%= data.versions.hbase_basename %>-<%= data.versions.hbase_variant %>
 ```
 
 You will need to at least add a minimal configuration to HBase to start it in
 standalone mode. Details can be found
 [here](http://hbase.apache.org/book/quickstart.html). Here, we are showing a
 sample minimal configuration.
-
 INFO: For production deployment, run a fully distributed HBase configuration.
-
-Edit `conf/hbase-site.xml` and put the following in. You may replace `/home/abc`
-with your own home directory.
-
+Edit `<%= data.versions.hbase_basename %>-<%= data.versions.hbase_variant %>/conf/hbase-site.xml`.
 ```
 <configuration>
   <property>
     <name>hbase.rootdir</name>
-    <value>file:///home/abc/hbase</value>
+    <value>file:///home/abc/<%= data.versions.hbase_basename %>-<%= data.versions.hbase_variant %></value>
   </property>
   <property>
     <name>hbase.zookeeper.property.dataDir</name>
@@ -109,15 +122,18 @@ with your own home directory.
 </configuration>
 ```
 
-Edit `conf/hbase-env.sh` to set `JAVA_HOME` for the cluster. For Mac users it
-would be
-
+Edit `<%= data.versions.hbase_basename %>-<%= data.versions.hbase_variant %>/conf/hbase-env.sh` to set `JAVA_HOME` for the cluster.
+For example:
 ```
-export JAVA_HOME=`/usr/libexec/java_home -v 1.7`
+export JAVA_HOME=`/usr/lib/jvm/java-8-oracle/jre`
+```
+
+In addition, you must set your environment variable `JAVA_HOME`.
+For example, in `/home/abc/.bashrc` add the following line:
+```
+export JAVA_HOME=`/usr/lib/jvm/java-8-oracle`
 ```
 
 <%= partial 'shared/install/dependent_services' %>
 
 Now you have installed everything you need!
-
-#### [Next: Recommendation Engine Quick Start](/templates/recommendation/quickstart/)


### PR DESCRIPTION
Using the original instructions on my Ubuntu 14.04.1 LTS digital ocean 2G droplet did not work.
I worked through the issues and updated the documentation to represent what worked and adjusted some sections that lead to confusion when following the steps from top to bottom command by command.