### PR TITLE
Changed events.json into my_events.json

### DIFF
--- a/docs/manual/source/datacollection/batchimport.html.md
+++ b/docs/manual/source/datacollection/batchimport.html.md
@@ -119,10 +119,10 @@ event_client.create_event('my_event', 'user', 'uid',
 
 Importing events from a file can be done easily using the command line
 interface. Assuming that `pio` be in your search path, your App ID be `123`, and
-the input file `events.json` be in your current working directory:
+the input file `my_events.json` be in your current working directory:
 
 ```bash
-$ pio import --appid 123 --input events.json
+$ pio import --appid 123 --input my_events.json
 ```
 
 After a brief while, the tool should return to the console without any error.


### PR DESCRIPTION
In the python sdk part, the script writes to my_events.json. In the example line below events.json is used.
When learning PredictionIO by copy-pasting examples without really getting what one is doing this might be confusing (That is the way I learned it in the first place :-)).
So would like to I suggest to be consistent in the SDK and line examples in this case.