### PR TITLE
Call jps from JAVA_HOME if JAVA_HOME is set

### DIFF
--- a/bin/pio-start-all
+++ b/bin/pio-start-all
@@ -25,7 +25,11 @@ export PIO_HOME="$(cd `dirname $0`/..; pwd)"
 # Elasticsearch
 echo "Starting Elasticsearch..."
 if [ -n "$PIO_STORAGE_SOURCES_ELASTICSEARCH_HOME" ]; then
-  JPS=`jps`
+  if [ -n "$JAVA_HOME" ]; then
+    JPS=`$JAVA_HOME/bin/jps`
+  else
+    JPS=`jps`
+  fi
   if [[ ${JPS} =~ "Elasticsearch" ]]; then
     echo -e "\033[0;31mElasticsearch is already running. Please use pio-stop-all to try stopping it first.\033[0m"
     echo -e "\033[0;31mNote: If you started Elasticsearch manually, you will need to kill it manually.\033[0m"


### PR DESCRIPTION
I'm using Fedora with Oracle Java that installed manually. 
During **pio-start-all**, I will see below error message:
> PredictionIO/bin/pio-start-all: line 28: jps: command not found

For my case, the **jps** is available in *JAVA_HOME/bin/jps* but not in *PATH*, unless configure **alias** or **update-alternatives** for **jps** manually. 

Suggest to call **jps** from *JAVA_HOME/bin* if *JAVA_HOME* is set, else remain to current behavior. 