### PR TITLE
Fix a bug due to an invalid column name when using JDBC as data source

### DIFF
--- a/data/src/main/scala/io/prediction/data/storage/jdbc/JDBCLEvents.scala
+++ b/data/src/main/scala/io/prediction/data/storage/jdbc/JDBCLEvents.scala
@@ -146,8 +146,8 @@ class JDBCLEvents(
     DB readOnly { implicit session =>
       val tableName = sqls.createUnsafely(JDBCUtils.eventTableName(namespace, appId, channelId))
       val whereClause = sqls.toAndConditionOpt(
-        startTime.map(x => sqls"startTime >= $x"),
-        untilTime.map(x => sqls"endTime < $x"),
+        startTime.map(x => sqls"eventTime >= $x"),
+        untilTime.map(x => sqls"eventTime < $x"),
         entityType.map(x => sqls"entityType = $x"),
         entityId.map(x => sqls"entityId = $x"),
         eventNames.map(x =>


### PR DESCRIPTION
When testing the Event Server with `data/test.sh` using PostgreSQL as datasource, the last test failed with the following message error.

```
400 Bad Request
Server: spray-can/1.3.2
Date: Tue, 21 Jul 2015 12:05:33 GMT
Content-Type: application/json; charset=UTF-8
Content-Length: 108

{"message":"org.postgresql.util.PSQLException: ERROR: column \"starttime\" does not exist\n  Position: 303"}
expect 200
```