### PR TITLE
Fix install.sh for Docker mode (Elastic Search + Hbase not installed)

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -71,6 +71,7 @@ if [[ "$OS" = "Linux" && $(cat /proc/1/cgroup) == *cpu:/docker/* ]]; then
   echo -e "\033[1;33mForcing Docker defaults!\033[0m"
   pio_dir=${PIO_DIR}
   vendors_dir=${pio_dir}/vendors
+  source_setup=${ES_HB}
 
   spark_dir=${vendors_dir}/spark-${SPARK_VERSION}
   elasticsearch_dir=${vendors_dir}/elasticsearch-${ELASTICSEARCH_VERSION}


### PR DESCRIPTION
The `source_setup` variable is not defined in Docker mode, so no database is installed.