### PR TITLE
JDBCApps. Fixed typo in INSERT SQL statement

### DIFF
--- a/data/src/main/scala/io/prediction/data/storage/jdbc/JDBCApps.scala
+++ b/data/src/main/scala/io/prediction/data/storage/jdbc/JDBCApps.scala
@@ -41,7 +41,7 @@ class JDBCApps(client: String, config: StorageClientConfig, prefix: String)
       """
     } else {
       sql"""
-      insert into $tableName values(${app.id}, ${app.name}, $app{description}())
+      insert into $tableName values(${app.id}, ${app.name}, ${app.description})
       """
     }
     Some(q.updateAndReturnGeneratedKey().apply().toInt)


### PR DESCRIPTION
JDBCApps. Fixed typo in INSERT SQL statement.

It was failing when MYSQL was used as a backend 