### PR TITLE
opened ability to get elasticsearch client config

### DIFF
--- a/data/src/main/scala/io/prediction/data/storage/Storage.scala
+++ b/data/src/main/scala/io/prediction/data/storage/Storage.scala
@@ -228,9 +228,10 @@ object Storage extends Logging {
 
   /** Get the StorageClient config data from PIO Framework's environment variables */
   def getConfig(sourceName: String): Option[StorageClientConfig] = {
-    if (s2cm.contains(sourceName) && s2cm.get(sourceName).nonEmpty && s2cm.get(sourceName).get.nonEmpty)
+    if (s2cm.contains(sourceName) && s2cm.get(sourceName).nonEmpty
+      && s2cm.get(sourceName).get.nonEmpty) {
       Some(s2cm.get(sourceName).get.get.config)
-    else None
+    } else None
   }
 
   private def updateS2CM(k: String, parallel: Boolean, test: Boolean):

--- a/data/src/main/scala/io/prediction/data/storage/Storage.scala
+++ b/data/src/main/scala/io/prediction/data/storage/Storage.scala
@@ -15,6 +15,8 @@
 
 package io.prediction.data.storage
 
+import java.lang.reflect.InvocationTargetException
+
 import grizzled.slf4j.Logging
 import io.prediction.annotation.DeveloperApi
 
@@ -208,8 +210,8 @@ object Storage extends Logging {
   }
 
   private def getClient(
-      clientConfig: StorageClientConfig,
-      pkg: String): BaseStorageClient = {
+    clientConfig: StorageClientConfig,
+    pkg: String): BaseStorageClient = {
     val className = "io.prediction.data.storage." + pkg + ".StorageClient"
     try {
       Class.forName(className).getConstructors()(0).newInstance(clientConfig).
@@ -222,6 +224,13 @@ object Storage extends Logging {
       case e: java.lang.reflect.InvocationTargetException =>
         throw e.getCause
     }
+  }
+
+  /** Get the StorageClient config data from PIO Framework's environment variables */
+  def getConfig(sourceName: String): Option[StorageClientConfig] = {
+    if (s2cm.contains(sourceName) && s2cm.get(sourceName).nonEmpty && s2cm.get(sourceName).get.nonEmpty)
+      Some(s2cm.get(sourceName).get.get.config)
+    else None
   }
 
   private def updateS2CM(k: String, parallel: Boolean, test: Boolean):

--- a/manifest.json
+++ b/manifest.json
@@ -1,1 +1,1 @@
-{"id":"AQUacEPKfAHhmU7wmxHErpEKiHwCJ1X0","version":"1d33d77ca11aaf0658d2f32e95d881007b406818","name":"PredictionIO","description":"pio-autogen-manifest","files":[],"engineFactory":""}
+{"id":"ipNrDsdxAtsDjZHRSAqfgOTL0PztjuR3","version":"b6a10c9f995426f7ee739156066bc26b577f2f09","name":"pio","description":"pio-autogen-manifest","files":[],"engineFactory":""}


### PR DESCRIPTION
added the ability to grab the auto-generated config data for a storage client so we can create an Elasticsearch transport client that understands clusternames and hosts as defined in pio-env