### PR TITLE
Use - instead of * for bullets

### DIFF
--- a/docs/manual/source/demo/tapster.html.md
+++ b/docs/manual/source/demo/tapster.html.md
@@ -28,10 +28,10 @@ The data structure looks like this:
 192,587 rows. Each row represents one user like for the given episode.
 
 The tutorial has four major steps:
-* Demo application setup
-* PredictionIO installation and setup
-* Import data into database and PredictionIO
-* Integrate demo application with PredictionIO
+- Demo application setup
+- PredictionIO installation and setup
+- Import data into database and PredictionIO
+- Integrate demo application with PredictionIO
 
 ## Tapster Demo Application
 The demo application is built using Rails.


### PR DESCRIPTION
It seems that asterisks for bullets work for github readme markdown, but not when rendered on the site. Further down this page, around lines 290-293, dashes are used instead. I assume these will now render properly.