### PR TITLE
Update deprecated zeppelin link to incubator link

### DIFF
--- a/docs/manual/source/datacollection/analytics-zeppelin.html.md.erb
+++ b/docs/manual/source/datacollection/analytics-zeppelin.html.md.erb
@@ -21,7 +21,7 @@ comes with PredictionIO at `$PIO_HOME/sbt/sbt`.
 Start by cloning Zeppelin.
 
 ```
-$ git clone https://github.com/NFLabs/zeppelin.git
+$ git clone https://github.com/apache/incubator-zeppelin.git
 ```
 
 Build Zeppelin with Hadoop 2.4 and Spark 1.2 profiles.


### PR DESCRIPTION
The existing installation can possibly output errors with incompatible version 0.0.20 of frontend-maven-plugin. Since it is also deprecated, it is better to change the link to the new one: https://github.com/apache/incubator-zeppelin.git