### PR TITLE
Change data type of event table to varchar(255)  when creating index.

### DIFF
--- a/data/src/main/scala/io/prediction/data/storage/jdbc/JDBCLEvents.scala
+++ b/data/src/main/scala/io/prediction/data/storage/jdbc/JDBCLEvents.scala
@@ -38,9 +38,38 @@ class JDBCLEvents(
   implicit private val formats = org.json4s.DefaultFormats
 
   def init(appId: Int, channelId: Option[Int] = None): Boolean = {
+
+    // To use index, it must be varchar less than 255 characters on a VARCHAR column
+    val useIndex = config.properties.contains("INDEX") &&
+      config.properties("INDEX").equalsIgnoreCase("enabled")
+
+    val tableName = JDBCUtils.eventTableName(namespace, appId, channelId)
+    val entityIdIndexName = s"idx_${tableName}_ei"
+    val entityTypeIndexName = s"idx_${tableName}_et"
     DB autoCommit { implicit session =>
-      SQL(s"""
-      create table if not exists ${JDBCUtils.eventTableName(namespace, appId, channelId)} (
+      if (useIndex) {
+        SQL(s"""
+      create table if not exists $tableName (
+        id varchar(32) not null primary key,
+        event varchar(255) not null,
+        entityType varchar(255) not null,
+        entityId varchar(255) not null,
+        targetEntityType text,
+        targetEntityId text,
+        properties text,
+        eventTime timestamp not null,
+        eventTimeZone varchar(50) not null,
+        tags text,
+        prId text,
+        creationTime timestamp not null,
+        creationTimeZone varchar(50) not null)""").execute().apply()
+
+        // create index
+        SQL(s"create index $entityIdIndexName on $tableName (entityId)").execute().apply()
+        SQL(s"create index $entityTypeIndexName on $tableName (entityType)").execute().apply()
+      } else {
+        SQL(s"""
+      create table if not exists $tableName (
         id varchar(32) not null primary key,
         event text not null,
         entityType text not null,
@@ -54,6 +83,7 @@ class JDBCLEvents(
         prId text,
         creationTime timestamp not null,
         creationTimeZone varchar(50) not null)""").execute().apply()
+      }
       true
     }
   }

--- a/docs/manual/source/system/anotherdatastore.html.md
+++ b/docs/manual/source/system/anotherdatastore.html.md
@@ -192,6 +192,13 @@ When `TYPE` is set to `jdbc`, the following configuration keys are supported.
     use when it reads from the JDBC connection, e.g.
     `PIO_STORAGE_SOURCES_PGSQL_PARTITIONS=4`
 
+-   INDEX (optional since v0.9.6, default to disabled)
+
+    This value is used by creating indexes on entityId and entityType columns to
+    improve performance when findByEntity function is called. Note that these columns 
+    of entityId and entityType will be created as varchar(255), e.g.
+    `PIO_STORAGE_SOURCES_PGSQL_INDEX=enabled`
+
 
 #### Apache HBase Configuration
 


### PR DESCRIPTION
 Improvement performance when findByEntity is called.

Closes #159