### PR TITLE
fix Cannot get a connection, pool error Timeout waiting for idle object

### DIFF
--- a/data/src/main/scala/io/prediction/data/storage/jdbc/StorageClient.scala
+++ b/data/src/main/scala/io/prediction/data/storage/jdbc/StorageClient.scala
@@ -36,10 +36,15 @@ class StorageClient(val config: StorageClientConfig)
     throw new StorageClientException("The PASSWORD variable is not set!", null)
   }
 
+  // set max size of connection pool
+  val maxSize: Int = config.properties.getOrElse("CONNECTIONS", "8").toInt
+  val settings = ConnectionPoolSettings(maxSize = maxSize)
+
   ConnectionPool.singleton(
     config.properties("URL"),
     config.properties("USERNAME"),
-    config.properties("PASSWORD"))
+    config.properties("PASSWORD"),
+    settings)
   /** JDBC connection URL. Connections are managed by ScalikeJDBC. */
   val client = config.properties("URL")
 }

--- a/docs/manual/source/system/anotherdatastore.html.md
+++ b/docs/manual/source/system/anotherdatastore.html.md
@@ -192,6 +192,11 @@ When `TYPE` is set to `jdbc`, the following configuration keys are supported.
     use when it reads from the JDBC connection, e.g.
     `PIO_STORAGE_SOURCES_PGSQL_PARTITIONS=4`
 
+-   CONNECTIONS (optional, default to 8)
+
+    This value is used by scalikejdbc library to determine the max size of connection pool, e.g.
+    `PIO_STORAGE_SOURCES_PGSQL_CONNECTIONS=8`
+
 -   INDEX (optional since v0.9.6, default to disabled)
 
     This value is used by creating indexes on entityId and entityType columns to


### PR DESCRIPTION
Add CONNECTIONS property for jdbc setting in pio-env.sh. 
It allows user to be able to set max size of connection pool instead of default value.

Closes #176