### PR TITLE
Use https when submitting user email to pio

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -172,7 +172,7 @@ else
       fi
       email=${email:-$guess_email}
 
-      url="http://direct.prediction.io/$PIO_VERSION/install.json/install/install/$email/"
+      url="https://direct.prediction.io/$PIO_VERSION/install.json/install/install/$email/"
       curl --silent ${url} > /dev/null
     fi
 


### PR DESCRIPTION
When installing pio using the install.sh script, users that subscribe to
updates submit their email to a direct.prediction.io endpoint using
http. Email is PII and should be transmitted using https.