### PR TITLE
[PIO-180] Livedoc readme link update

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A few installation options available.
 *   [Installing Apache PredictionIO from
     Binary/Source](http://predictionio.apache.org/install/install-sourcecode/)
 *   [Installing Apache PredictionIO with
-    Docker](http://predictionio.apache.org/community/projects/#docker-installation-for-predictionio)
+    Docker](http://predictionio.apache.org/community/projects/#docker-images)
     (community contributed)
 
 


### PR DESCRIPTION
[#docker-installation-for-predictionio](http://predictionio.apache.org/community/projects/#docker-installation-for-predictionio) change to [#docker-images](http://predictionio.apache.org/community/projects/#docker-images) in livedoc readme