### PR TITLE
Fixed docker's build failure

### DIFF
--- a/docker/pio/Dockerfile
+++ b/docker/pio/Dockerfile
@@ -56,7 +56,7 @@ RUN curl -o $PIO_HOME/lib/postgresql-$PGSQL_VERSION.jar \
 
 WORKDIR /usr/share
 RUN curl -o /opt/src/spark-$SPARK_VERSION.tgz \
-    http://www-us.apache.org/dist/spark/spark-$SPARK_VERSION/spark-$SPARK_VERSION-bin-hadoop2.7.tgz && \
+    http://archive.apache.org/dist/spark/spark-$SPARK_VERSION/spark-$SPARK_VERSION-bin-hadoop2.7.tgz && \
     tar zxvf /opt/src/spark-$SPARK_VERSION.tgz && \
     echo "SPARK_HOME="`pwd`/`ls -d spark*` >> /etc/predictionio/pio-env.sh && \
     rm -rf /opt/src


### PR DESCRIPTION
The docker build was failing at step 19/24 due to spark's download URL [original URL](http://www-us.apache.org/dist/spark/spark-2.2.3/spark-2.2.3-bin-hadoop2.7.tgz) hit HTTP 404 error.

I have updated the link to point to [archive URL](https://archive.apache.org/dist/spark/spark-2.2.3/spark-2.2.3-bin-hadoop2.7.tgz) which contains correct location of the file. And also safer to use as its housing old versions and latest versions as well.