### PR TITLE
[PIO-214] use openjdk8 as oraclejdk8 is no longer available in the default Travis build image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ branches:
 language: scala
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 services:
   - docker


### PR DESCRIPTION
The build on develop is failing, likely because of the following change made by Travis-CI:[ Ubuntu Xenial 16.04 as the default Travis CI build environment](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment). It's been referenced in [several Travis CI questions about Oracle JDK 8](https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/13) that the way to resolve the issues is to either force the build dist to use 'trusty', or we could switch to building with OpenJDK.