### PR TITLE
Update maven repo URL

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -391,7 +391,7 @@ case $source_setup in
       echo -e "\033[1;31mPlease install MySQL manually!\033[0m"
       exit 4
     fi
-    curl -O http://central.maven.org/maven2/mysql/mysql-connector-java/5.1.37/mysql-connector-java-${MYSQL_VERSION}.jar
+    curl -O https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.37/mysql-connector-java-${MYSQL_VERSION}.jar
     mv mysql-connector-java-${MYSQL_VERSION}.jar ${pio_dir}/lib/
     ;;
   "$ES_HB")

--- a/docker/pio/Dockerfile
+++ b/docker/pio/Dockerfile
@@ -50,7 +50,7 @@ RUN bash ./make-distribution.sh \
 RUN cp /etc/predictionio/pio-env.sh /etc/predictionio/pio-env.sh.orig && \
     echo "#!/usr/bin/env bash" > /etc/predictionio/pio-env.sh
 RUN curl -o $PIO_HOME/lib/postgresql-$PGSQL_VERSION.jar \
-    http://central.maven.org/maven2/org/postgresql/postgresql/$PGSQL_VERSION/postgresql-$PGSQL_VERSION.jar && \
+    https://repo1.maven.org/maven2/org/postgresql/postgresql/$PGSQL_VERSION/postgresql-$PGSQL_VERSION.jar && \
     echo "POSTGRES_JDBC_DRIVER=$PIO_HOME/lib/postgresql-$PGSQL_VERSION.jar" >> /etc/predictionio/pio-env.sh && \
     echo "MYSQL_JDBC_DRIVER=$PIO_HOME/lib/mysql-connector-java-$MYSQL_VERSION.jar" >> /etc/predictionio/pio-env.sh
 

--- a/docker/pio/pio_run
+++ b/docker/pio/pio_run
@@ -39,7 +39,7 @@ fi
 if [ x"$PIO_STORAGE_SOURCES_MYSQL_TYPE" != "x" ] ; then
   MYSQL_JAR_FILE=$PIO_HOME/lib/mysql-connector-java-$MYSQL_VERSION.jar
   if [ ! -f $MYSQL_JAR_FILE ] ; then
-    curl -o $MYSQL_JAR_FILE http://central.maven.org/maven2/mysql/mysql-connector-java/$MYSQL_VERSION/mysql-connector-java-$MYSQL_VERSION.jar
+    curl -o $MYSQL_JAR_FILE https://repo1.maven.org/maven2/mysql/mysql-connector-java/$MYSQL_VERSION/mysql-connector-java-$MYSQL_VERSION.jar
   fi
 fi
 


### PR DESCRIPTION
central.maven.org was deprecated on July'19 https://central.sonatype.org/articles/2019/Jul/15/central-http-deprecation-update/